### PR TITLE
Update Chinese_Simplified.xml

### DIFF
--- a/app/Chinese_Simplified.xml
+++ b/app/Chinese_Simplified.xml
@@ -49,7 +49,7 @@
         <treeItemFileSystem>文件系统 (%d 个项目)</treeItemFileSystem>
         <treeItemRegistry>注册表 (%d 个项目)</treeItemRegistry>
         <treeItemPopopMenuBrowse>浏览...</treeItemPopopMenuBrowse>
-        <btnFinish>完成</btnFinish>
+        <btnFinish>删除</btnFinish>
         <btnCancel>取消</btnCancel>
         <btnClose>关闭</btnClose>
     </UninstallWizard>


### PR DESCRIPTION
"Finish" here does not make it obvious that you want to delete the residual files.
It is more of a confirmation that the uninstallation is complete.
So I suggest changing the button title to "Delete" or "Delete and Exit".

"完成"在这里并不能明显地表达为要删除残留文件。
更多地是代表卸载完成后的一个确认
因此建议将按钮标题修改为"删除"，或者"删除并退出"